### PR TITLE
few fix for transporter

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,7 +11,9 @@ config :trivia_advisor, TriviaAdvisor.Repo,
   timeout: 30_000,
   queue_target: 5_000,
   queue_interval: 1_000,
-  show_sensitive_data_on_connection_error: true
+  show_sensitive_data_on_connection_error: true,
+  # Disable prepared statements for PgBouncer compatibility
+  prepare: :unnamed
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -55,7 +55,9 @@ if config_env() == :prod do
   config :trivia_advisor, TriviaAdvisor.Repo,
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    socket_options: maybe_ipv6
+    socket_options: maybe_ipv6,
+    # Disable prepared statements for PgBouncer compatibility
+    prepare: :unnamed
 
   config :trivia_advisor, TriviaAdvisorWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],


### PR DESCRIPTION
### TL;DR

Disabled prepared statements in database configuration for PgBouncer compatibility.

### What changed?

Added `prepare: :unnamed` configuration option to both development and production database configurations to disable prepared statements. This change ensures compatibility with PgBouncer connection pooler.

### How to test?

1. Verify the application connects to the database successfully in development environment
2. If possible, test with a PgBouncer setup to confirm compatibility
3. Ensure database queries continue to work as expected

### Why make this change?

PgBouncer doesn't fully support prepared statements in transaction pooling mode. By setting `prepare: :unnamed`, we're ensuring our application will work correctly when deployed with PgBouncer as a connection pooler, which is important for production scalability and connection management.