### PR TITLE
toml changes

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,7 @@ kill_signal = 'SIGTERM'
 [build]
 
 [env]
-  PHX_HOST = 'quiz-advisor.fly.dev'
+  PHX_HOST = 'beta.quizadvisor.com'
   PORT = '8080'
   PHX_SERVER = 'true'
 

--- a/lib/trivia_advisor_web.ex
+++ b/lib/trivia_advisor_web.ex
@@ -17,7 +17,7 @@ defmodule TriviaAdvisorWeb do
   those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+  def static_paths, do: ~w(assets fonts images favicon.ico)
 
   def router do
     quote do

--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -1,5 +1,0 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /


### PR DESCRIPTION
### TL;DR

Updated domain from fly.dev to beta.quizadvisor.com and removed robots.txt

### What changed?

- Changed `PHX_HOST` in fly.toml from 'quiz-advisor.fly.dev' to 'beta.quizadvisor.com'
- Removed robots.txt from static_paths in TriviaAdvisorWeb module
- Deleted the robots.txt file from priv/static directory

### How to test?

1. Deploy the application and verify it's accessible at https://beta.quizadvisor.com
2. Confirm that robots.txt is no longer accessible at https://beta.quizadvisor.com/robots.txt

### Why make this change?

We're moving from the default fly.dev domain to our custom domain beta.quizadvisor.com. We've also removed the robots.txt file as we don't want to provide specific crawling instructions for the beta environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application deployment host to beta.quizadvisor.com
  * Removed robots.txt from static assets configuration, updating search engine crawling behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->