### PR TITLE
caching of the sitemap

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -113,7 +113,14 @@ if config_env() == :prod do
       ip: {0, 0, 0, 0, 0, 0, 0, 0},
       port: port
     ],
-    secret_key_base: secret_key_base
+    secret_key_base: secret_key_base,
+    # Allow WebSocket connections from the configured host and www subdomain
+    # This is critical for LiveView to work - without it, the WebSocket upgrade
+    # fails silently and pages appear to never finish loading
+    check_origin: [
+      "https://#{host}",
+      "https://www.#{host}"
+    ]
 
   # ## SSL Support
   #

--- a/lib/trivia_advisor/application.ex
+++ b/lib/trivia_advisor/application.ex
@@ -12,11 +12,23 @@ defmodule TriviaAdvisor.Application do
       TriviaAdvisor.Repo,
       {DNSCluster, query: Application.get_env(:trivia_advisor, :dns_cluster_query) || :ignore},
       # ConCache for query result caching with 15-minute TTL
-      {ConCache, [
-        name: :city_cache,
-        ttl_check_interval: :timer.minutes(1),
-        global_ttl: :timer.minutes(15)
-      ]},
+      Supervisor.child_spec(
+        {ConCache, [
+          name: :city_cache,
+          ttl_check_interval: :timer.minutes(1),
+          global_ttl: :timer.minutes(15)
+        ]},
+        id: :city_cache
+      ),
+      # ConCache for sitemap caching with 6-hour TTL (regenerates 4x daily)
+      Supervisor.child_spec(
+        {ConCache, [
+          name: :sitemap_cache,
+          ttl_check_interval: :timer.minutes(5),
+          global_ttl: :timer.hours(6)
+        ]},
+        id: :sitemap_cache
+      ),
       {Phoenix.PubSub, name: TriviaAdvisor.PubSub},
       # Start a worker by calling: TriviaAdvisor.Worker.start_link(arg)
       # {TriviaAdvisor.Worker, arg},

--- a/lib/trivia_advisor_web/controllers/sitemap_controller.ex
+++ b/lib/trivia_advisor_web/controllers/sitemap_controller.ex
@@ -7,12 +7,14 @@ defmodule TriviaAdvisorWeb.SitemapController do
 
   @doc """
   Serves the sitemap.xml file.
+  Uses ConCache to serve cached XML (6-hour TTL).
   """
   def sitemap(conn, _params) do
-    sitemap_xml = TriviaAdvisor.Sitemap.to_xml()
+    sitemap_xml = TriviaAdvisor.Sitemap.get_cached_xml()
 
     conn
     |> put_resp_content_type("application/xml")
+    |> put_resp_header("cache-control", "public, max-age=3600")
     |> send_resp(200, sitemap_xml)
   end
 

--- a/lib/trivia_advisor_web/live/latest_events_live.ex
+++ b/lib/trivia_advisor_web/live/latest_events_live.ex
@@ -18,11 +18,14 @@ defmodule TriviaAdvisorWeb.LatestEventsLive do
 
     # Fetch latest venues (more than homepage shows)
     latest_venues = Locations.get_latest_venues(@default_limit)
+    has_venues = length(latest_venues) > 0
 
     socket =
       socket
       |> assign(:page_title, "Latest Trivia Events")
-      |> assign(:latest_venues, latest_venues)
+      |> stream_configure(:latest_venues, dom_id: &"venue-#{&1.venue_id}")
+      |> stream(:latest_venues, latest_venues)
+      |> assign(:has_venues, has_venues)
       |> assign(:base_url, base_url)
 
     {:ok, socket}
@@ -78,7 +81,7 @@ defmodule TriviaAdvisorWeb.LatestEventsLive do
 
         <!-- Venues Grid -->
         <div class="container mx-auto px-4 py-12">
-          <%= if Enum.empty?(@latest_venues) do %>
+          <%= if not @has_venues do %>
             <!-- Empty State -->
             <div class="text-center py-12">
               <svg
@@ -107,10 +110,10 @@ defmodule TriviaAdvisorWeb.LatestEventsLive do
             </div>
           <% else %>
             <!-- Venue Cards Grid -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
-              <%= for venue <- @latest_venues do %>
+            <div id="latest-venues" phx-update="stream" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+              <div :for={{dom_id, venue} <- @streams.latest_venues} id={dom_id}>
                 <VenueCard.venue_card venue={venue} show_city={true} />
-              <% end %>
+              </div>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
### TL;DR

Implemented sitemap caching and improved LiveView WebSocket connectivity for production.

### What changed?

- Added `check_origin` configuration for WebSocket connections in production to fix LiveView loading issues
- Implemented a sitemap caching system with a 6-hour TTL using ConCache to reduce database load
- Added cache-control headers to sitemap responses for better HTTP caching
- Converted the latest events page to use Phoenix LiveView streams for more efficient DOM updates

### How to test?

1. Verify that LiveView pages load correctly in production with WebSockets
2. Check that the sitemap.xml endpoint responds quickly even with many URLs
3. Verify that the sitemap cache regenerates every 6 hours
4. Confirm that the latest events page loads and updates correctly using streams

### Why make this change?

The WebSocket configuration was necessary to fix LiveView in production, where pages would appear to never finish loading due to failed WebSocket connections. The sitemap caching system significantly reduces database load by avoiding expensive queries on every sitemap request. Using LiveView streams for the latest events page improves performance by only updating changed DOM elements rather than re-rendering the entire list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Sitemap generation is now cached, with 1-hour browser-side caching enabled to reduce page load times
  * Latest events section now uses optimized streaming for smoother, more responsive real-time updates

* **Security Enhancements**
  * Enhanced WebSocket connection security through stricter origin verification to prevent unauthorized access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->