### PR TITLE
final

### DIFF
--- a/CACHE_AUDIT_PHASE1.md
+++ b/CACHE_AUDIT_PHASE1.md
@@ -51,7 +51,7 @@ Added caching to previously uncached `events.ex` functions:
 |----------|-------------------|---------------|
 | `get_events_for_venue/1` | `events_for_venue_{venue_id}` | `events.ex:35-42` |
 | `get_events_for_weekday/2` | `events_weekday_{day}_limit_{limit}` | `events.ex:60-67` |
-| `get_events_by_type/2` | `events_by_type_limit_{limit}` | `events.ex:85-91` |
+| `get_events_by_type/2` | ~~Removed~~ (dead code, view pre-filters to trivia) | N/A |
 | `get_event/1` | `event_{id}` | `events.ex:110-115` |
 
 ### Geo Cache Key Analysis
@@ -148,7 +148,7 @@ All 21 `ConCache.get_or_store` calls use `:city_cache`.
 |----------|---------|------------|-------------------|
 | `get_events_for_venue/1` | ~~NO~~ → **YES (Phase 3)** | **Full schema** | **YES** |
 | `get_events_for_weekday/2` | ~~NO~~ → **YES (Phase 3)** | **Full schema** | **YES** |
-| `get_events_by_type/2` | ~~NO~~ → **YES (Phase 3)** | **Full schema** | **YES** |
+| `get_events_by_type/2` | ~~Removed~~ (dead code) | N/A | N/A |
 | `get_event/1` | ~~NO~~ → **YES (Phase 3)** | **Full schema** | **YES** |
 | `get_nearby_trivia_venues/2` | Yes | Explicit select (no venue_images) | No |
 

--- a/lib/trivia_advisor/events.ex
+++ b/lib/trivia_advisor/events.ex
@@ -68,30 +68,6 @@ defmodule TriviaAdvisor.Events do
   end
 
   @doc """
-  Gets trivia events from trivia_events_export view.
-  The view already filters to trivia-only, so type parameter is ignored.
-
-  Results are cached for 24 hours (matches materialized view refresh cycle).
-  See: https://github.com/razrfly/eventasaurus/issues/3026
-
-  ## Examples
-
-      iex> get_events_by_type("trivia")
-      [%PublicEvent{}, ...]
-  """
-  def get_events_by_type(_event_type, opts \\ []) do
-    limit = Keyword.get(opts, :limit, 50)
-
-    ConCache.get_or_store(:city_cache, "events_by_type_limit_#{limit}", fn ->
-      Repo.all(
-        from e in PublicEvent,
-          order_by: e.name,
-          limit: ^limit
-      )
-    end)
-  end
-
-  @doc """
   Gets a single trivia event by ID from trivia_events_export view.
   Returns nil if the event is not in the view.
 


### PR DESCRIPTION
### TL;DR

Removed unused `get_events_by_type/2` function and updated documentation to reflect this change.

### What changed?

- Removed the `get_events_by_type/2` function from `events.ex` as it was identified as dead code
- Updated `CACHE_AUDIT_PHASE1.md` to mark this function as removed instead of scheduled for Phase 3 caching
- Added a note that the view pre-filters to trivia events, making this function redundant

### How to test?

- Verify that no part of the application calls `get_events_by_type/2`
- Confirm that the application builds and runs without errors
- Check that any functionality previously using this function still works correctly with the pre-filtered view

### Why make this change?

This change removes dead code that was not being used in the application. The function was redundant since the view already pre-filters to trivia events. Removing unused code improves maintainability and reduces confusion for developers working on the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused event type filtering function and its associated caching mechanism. Other event retrieval capabilities remain fully functional and unaffected by this change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->